### PR TITLE
Extract logistic scaling magic number

### DIFF
--- a/src/admete/evaluate.cpp
+++ b/src/admete/evaluate.cpp
@@ -44,7 +44,7 @@ score_t Evaluation::eval(const Board &board) {
     // Return the eval from the point of view of the current player.
     Neural::nn_t nn = network.forward(board.accumulator(), board.who_to_play());
     // TODO: Why think about centipawns at all, ideally we'd just map the output to the score_t range.
-    auto mapped = std::clamp(static_cast<score_t>(nn*400.), static_cast<score_t>(1-MIN_MATE_SCORE), static_cast<score_t>(MIN_MATE_SCORE-1)); 
+    auto mapped = std::clamp(static_cast<score_t>(nn * Neural::LOGISTIC_SCALING), static_cast<score_t>(1-MIN_MATE_SCORE), static_cast<score_t>(MIN_MATE_SCORE-1)); 
     return mapped;
 }
 

--- a/src/admete/neural/weights.hpp
+++ b/src/admete/neural/weights.hpp
@@ -9,6 +9,7 @@ namespace Neural {
 
 constexpr uint8_t ACC_SHIFT = 4;
 constexpr size_t N_ACCUMULATED = 256;
+constexpr nn_t LOGISTIC_SCALING = 400.0f;
 static_assert(N_FEATURES == 384, "Feature size mismatch");
 
 namespace generated {


### PR DESCRIPTION
Promotes the `400.` magic number in `Evaluation::eval` to a named `Neural::LOGISTIC_SCALING` constant.